### PR TITLE
Django 1.5 was changed in https://code.djangoproject.com/ticket/19316 so

### DIFF
--- a/flows/handler.py
+++ b/flows/handler.py
@@ -410,7 +410,17 @@ class FlowPositionInstance(object):
 
         if response is None:
             # now that everything is set up, we can handle the request
-            response = self.get_action().dispatch(request, *args, **kwargs)
+
+            # FIXME: mjtamlyn promises to fix this in Django 1.7, but right now we need
+            # to set up the magic attributes usually set up by a closure in View.as_view
+            # so we can call dispatch on Django>1.5
+            action = self.get_action()
+            if hasattr(action, 'request'):
+                raise Exception('Action re-use?')
+            action.request = request
+            action.args = args
+            action.kwargs = kwargs
+            response = action.dispatch(request, *args, **kwargs)
 
             # if this is a GET request, then we displayed something to the user, so
             # we should record this in the history, unless the request returned a


### PR DESCRIPTION
that `View.as_view` is really the only trouble-free entry point for a
class-based view. Unfortunately that conflicts with django-flows'
strategy of callig `View.dispatch` directly on `Action`s.

Reported:
https://groups.google.com/forum/#!topic/django-developers/a4SH3YJwAi4

After a lengthy IRC discussion we were promised a fix in Django 1.7,
until then we'll have to rely on the kludge of setting up the
magic attributes ourselves.
